### PR TITLE
Bump react version to 15.3.2

### DIFF
--- a/extensions/roc-plugin-react/package.json
+++ b/extensions/roc-plugin-react/package.json
@@ -23,8 +23,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "react": "~15.0.1",
-    "react-dom": "~15.0.1",
+    "react": "^15.3.2",
+    "react-dom": "^15.3.2",
     "roc": "^1.0.0-rc.12"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes

Bump react and react-dom version to 15.3.2

Use semver prefix ^ instead of ~ for react versions as mentioned in #6 
