### PR TITLE
Export the standalone prop-types module and bump dependencies

### DIFF
--- a/extensions/roc-plugin-react-dev/package.json
+++ b/extensions/roc-plugin-react-dev/package.json
@@ -27,7 +27,7 @@
     "babel-preset-react": "~6.3.13",
     "react-transform-catch-errors": "~1.0.2",
     "react-transform-hmr": "~1.0.2",
-    "redbox-react": "~1.2.3"
+    "redbox-react": "~1.3.6"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",

--- a/extensions/roc-plugin-react/package.json
+++ b/extensions/roc-plugin-react/package.json
@@ -23,8 +23,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "roc": "^1.0.0-rc.12"
   },
   "devDependencies": {

--- a/extensions/roc-plugin-react/src/roc/index.js
+++ b/extensions/roc-plugin-react/src/roc/index.js
@@ -5,6 +5,7 @@ const packageJSON = require('../../package.json');
 export default {
     dependencies: {
         exports: generateDependencies(packageJSON, [
+            'prop-types',
             'react',
             'react-dom',
         ]),


### PR DESCRIPTION
This makes the plugin compatible with the latest version of React.